### PR TITLE
refactor: angular tiles and html-to-image export

### DIFF
--- a/ScrimPrep/immortal_war_configurator_react.jsx
+++ b/ScrimPrep/immortal_war_configurator_react.jsx
@@ -5,46 +5,168 @@ const { useMemo, useState } = React;
    Data: Maps + Characters
    ========================= */
 const DEFAULT_MAPS = [
-  { name: "Morus Isle", imageUrl: "https://static1.thegamerimages.com/wordpress/wp-content/uploads/2021/08/Naraka-Bladepoint-Beginners-Tips-And-Tricks.jpg" },
-  { name: "Holoroth", imageUrl: "https://www.narakathegame.com/pc/zt/20220722165632/img/bg_ab32b039.jpg" },
-  { name: "Perdoria", imageUrl: "https://nie.res.netease.com/r/pic/20240702/e22a5db3-18bb-404f-9843-d42fb2d83ad8.png" }
+  {
+    name: "Morus Isle",
+    imageUrl:
+      "https://static1.thegamerimages.com/wordpress/wp-content/uploads/2021/08/Naraka-Bladepoint-Beginners-Tips-And-Tricks.jpg",
+  },
+  {
+    name: "Holoroth",
+    imageUrl:
+      "https://www.narakathegame.com/pc/zt/20220722165632/img/bg_ab32b039.jpg",
+  },
+  {
+    name: "Perdoria",
+    imageUrl:
+      "https://nie.res.netease.com/r/pic/20240702/e22a5db3-18bb-404f-9843-d42fb2d83ad8.png",
+  },
 ];
 
 const DEFAULT_CHARACTERS = [
-  { name: "Viper Ning", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_mangjianke_01.png" },
-  { name: "Feria Shen", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_shenmiao_01.png" },
-  { name: "Tianhai", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_youseng_01.png" },
-  { name: "Ziping Yin", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yinziping_01.png" },
-  { name: "Temulch", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_caoyuan_01.png" },
-  { name: "Tarka Ji", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_haoxia_01.png" },
-  { name: "Kurumi", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_onmyoji_01.png" },
-  { name: "Yoto Hime", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yaodaoji_01.png" },
-  { name: "Valda Cui", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_cuisanniang_01.png" },
-  { name: "Yueshan", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yueshan_01.png" },
-  { name: "Wuchen", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wuchen_01.png" },
-  { name: "Justina Gu", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_guqinghan_01.png" },
-  { name: "Takeda Nobutada", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wutian_01.png" },
-  { name: "Matari", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_hanhaimomin_01.png" },
-  { name: "Akos Hu", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_huwei_01.png" },
-  { name: "Zai", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_jiyingying_01.png" },
-  { name: "Tessa", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yulinglong_01.png" },
-  { name: "Hadi", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_hadi_01.png" },
-  { name: "Shayol Wei", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_weiqing_01.png" },
-  { name: "Lyam Liu", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_liulian_01.png" },
-  { name: "Kylin Zhang", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_zhangqiling_01.png" },
-  { name: "Cyra", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_xila_01.png" },
-  { name: "Lannie", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_lanmeng_01.png" },
-  { name: "Inor Wan", avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wanjun_01.png" }
+  {
+    name: "Viper Ning",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_mangjianke_01.png",
+  },
+  {
+    name: "Feria Shen",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_shenmiao_01.png",
+  },
+  {
+    name: "Tianhai",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_youseng_01.png",
+  },
+  {
+    name: "Ziping Yin",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_yinziping_01.png",
+  },
+  {
+    name: "Temulch",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_caoyuan_01.png",
+  },
+  {
+    name: "Tarka Ji",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_haoxia_01.png",
+  },
+  {
+    name: "Kurumi",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_onmyoji_01.png",
+  },
+  {
+    name: "Yoto Hime",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yaodaoji_01.png",
+  },
+  {
+    name: "Valda Cui",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_cuisanniang_01.png",
+  },
+  {
+    name: "Yueshan",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_yueshan_01.png",
+  },
+  {
+    name: "Wuchen",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wuchen_01.png",
+  },
+  {
+    name: "Justina Gu",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_guqinghan_01.png",
+  },
+  {
+    name: "Takeda Nobutada",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wutian_01.png",
+  },
+  {
+    name: "Matari",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_hanhaimomin_01.png",
+  },
+  {
+    name: "Akos Hu",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_huwei_01.png",
+  },
+  {
+    name: "Zai",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_jiyingying_01.png",
+  },
+  {
+    name: "Tessa",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_yulinglong_01.png",
+  },
+  {
+    name: "Hadi",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_hadi_01.png",
+  },
+  {
+    name: "Shayol Wei",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_weiqing_01.png",
+  },
+  {
+    name: "Lyam Liu",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_liulian_01.png",
+  },
+  {
+    name: "Kylin Zhang",
+    avatarUrl:
+      "https://naraka.wiki/icon_hero_select/icon_hero_zhangqiling_01.png",
+  },
+  {
+    name: "Cyra",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_xila_01.png",
+  },
+  {
+    name: "Lannie",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_lanmeng_01.png",
+  },
+  {
+    name: "Inor Wan",
+    avatarUrl: "https://naraka.wiki/icon_hero_select/icon_hero_wanjun_01.png",
+  },
 ];
 
 // Hardcoded round rotation
 const ROUND_ROTATION = [
-  { map: "Perdoria", mapImage: DEFAULT_MAPS[2].imageUrl, timeOfDay: "Midnight", fireflies: true },
-  { map: "Holoroth", mapImage: DEFAULT_MAPS[1].imageUrl, timeOfDay: "Sunny", fireflies: false },
-  { map: "Morus Isle", mapImage: DEFAULT_MAPS[0].imageUrl, timeOfDay: "Noon", fireflies: false },
-  { map: "Perdoria", mapImage: DEFAULT_MAPS[2].imageUrl, timeOfDay: "Morning Dew", fireflies: false },
-  { map: "Holoroth", mapImage: DEFAULT_MAPS[1].imageUrl, timeOfDay: "Dusk", fireflies: true },
-  { map: "Morus Isle", mapImage: DEFAULT_MAPS[0].imageUrl, timeOfDay: "Night", fireflies: true },
+  {
+    map: "Perdoria",
+    mapImage: DEFAULT_MAPS[2].imageUrl,
+    timeOfDay: "Midnight",
+    fireflies: true,
+  },
+  {
+    map: "Holoroth",
+    mapImage: DEFAULT_MAPS[1].imageUrl,
+    timeOfDay: "Sunny",
+    fireflies: false,
+  },
+  {
+    map: "Morus Isle",
+    mapImage: DEFAULT_MAPS[0].imageUrl,
+    timeOfDay: "Noon",
+    fireflies: false,
+  },
+  {
+    map: "Perdoria",
+    mapImage: DEFAULT_MAPS[2].imageUrl,
+    timeOfDay: "Morning Dew",
+    fireflies: false,
+  },
+  {
+    map: "Holoroth",
+    mapImage: DEFAULT_MAPS[1].imageUrl,
+    timeOfDay: "Dusk",
+    fireflies: true,
+  },
+  {
+    map: "Morus Isle",
+    mapImage: DEFAULT_MAPS[0].imageUrl,
+    timeOfDay: "Night",
+    fireflies: true,
+  },
 ];
 
 /** @typedef {{round:number,map:string,mapImage:string,timeOfDay:string,character:string}} RoundSelection */
@@ -57,7 +179,8 @@ const ROUND_ROTATION = [
 
 const findMapByName = (maps, name) => (maps || []).find((m) => m.name === name);
 const classNames = (...xs) => xs.filter(Boolean).join(" ");
-const characterAvatar = (characters, name) => (characters || []).find((x) => x.name === name)?.avatarUrl || "";
+const characterAvatar = (characters, name) =>
+  (characters || []).find((x) => x.name === name)?.avatarUrl || "";
 
 /* =========================
    Round Card
@@ -66,22 +189,41 @@ function RoundCard({ idx, selection, maps, characters, onChange, errors }) {
   const { map, mapImage, timeOfDay, character, fireflies } = selection;
   const avatarUrl = characterAvatar(characters, character);
   // Use mapImage from selection, fallback to lookup from maps
-  const effectiveMapImage = mapImage || (maps && findMapByName(maps, map)?.imageUrl) || "";
+  const effectiveMapImage =
+    mapImage || (maps && findMapByName(maps, map)?.imageUrl) || "";
 
   return (
-    <div className="rounded-2xl border border-gray-700/70 bg-black/40 backdrop-blur-sm p-4 shadow-sm flex flex-col justify-between w-full" style={{minHeight:'180px',maxHeight:'180px',maxWidth:'520px',width:'100%'}}>
+    <div
+      className="rounded-2xl border border-gray-700/70 bg-black/40 backdrop-blur-sm p-4 shadow-sm flex flex-col justify-between w-full group"
+      style={{
+        minHeight: "180px",
+        maxHeight: "180px",
+        maxWidth: "520px",
+        width: "100%",
+      }}
+    >
       <div className="flex flex-col w-full">
-        <div className="flex flex-row items-center w-full" style={{height:'90px', position:'relative'}}>
-          {/* Map preview - fixed size, cropped, square, no rounding */}
-          <div className="relative border border-gray-700 shadow-inner flex-shrink-0" style={{width:'calc(100% - 92px)', height:'90px', borderRadius:0, overflow:'hidden'}}>
+        <div
+          className="flex flex-row items-center w-full"
+          style={{ height: "90px", position: "relative" }}
+        >
+          {/* Map preview */}
+          <div
+            className="relative border border-gray-700 shadow-inner flex-shrink-0 angled-tile"
+            style={{ width: "calc(100% - 92px)", height: "90px" }}
+          >
             {effectiveMapImage ? (
               <img
                 src={effectiveMapImage}
                 alt={map || "Map"}
-                style={{width:'100%',height:'100%',objectFit:'cover',borderRadius:0,display:'block'}}
+                className="w-full h-full object-cover"
                 loading="lazy"
+                crossOrigin="anonymous"
                 referrerPolicy="no-referrer"
-                onError={e => { e.currentTarget.src = "https://via.placeholder.com/960x540?text=Map+Preview"; }}
+                onError={(e) => {
+                  e.currentTarget.src =
+                    "https://via.placeholder.com/960x540?text=Map+Preview";
+                }}
               />
             ) : (
               <div className="w-full h-full bg-gray-800/70 flex items-center justify-center text-xs text-gray-400">
@@ -105,18 +247,28 @@ function RoundCard({ idx, selection, maps, characters, onChange, errors }) {
             </div>
           </div>
           {/* 2px padding between map and hero image */}
-          <div style={{width:'2px',height:'90px'}} />
-          {/* Character tile - same height as map, square, no rounding */}
-          <div className="flex items-center justify-center flex-shrink-0" style={{width:'90px',height:'90px'}}>
-            <div className="border border-gray-700 shadow flex items-center justify-center" style={{width:'90px',height:'90px',borderRadius:0,overflow:'hidden'}}>
+          <div style={{ width: "2px", height: "90px" }} />
+          {/* Character tile */}
+          <div
+            className="flex items-center justify-center flex-shrink-0"
+            style={{ width: "90px", height: "90px" }}
+          >
+            <div
+              className="border border-gray-700 shadow flex items-center justify-center hero-tile"
+              style={{ width: "90px", height: "90px" }}
+            >
               {avatarUrl ? (
                 <img
                   src={avatarUrl}
                   alt={character || "Character"}
-                  style={{width:'100%',height:'100%',objectFit:'cover',borderRadius:0,display:'block'}}
+                  className="w-full h-full object-cover"
                   loading="lazy"
+                  crossOrigin="anonymous"
                   referrerPolicy="no-referrer"
-                  onError={e => { e.currentTarget.src = "https://via.placeholder.com/300x300?text=Avatar"; }}
+                  onError={(e) => {
+                    e.currentTarget.src =
+                      "https://via.placeholder.com/300x300?text=Avatar";
+                  }}
                 />
               ) : (
                 <div className="w-full h-full bg-gray-800" />
@@ -125,23 +277,32 @@ function RoundCard({ idx, selection, maps, characters, onChange, errors }) {
           </div>
         </div>
         {/* Character select below each card, inside box and visually contained */}
-        <div className="mt-2 w-full" style={{paddingLeft:0,paddingRight:0,boxSizing:'border-box'}}>
-          <label className="block text-sm font-medium mb-0.5 text-gray-300">Character</label>
+        <div
+          className="mt-2 w-full"
+          style={{ paddingLeft: 0, paddingRight: 0, boxSizing: "border-box" }}
+        >
+          <label className="block text-sm font-medium mb-0.5 text-gray-300">
+            Character
+          </label>
           <select
             className={classNames(
               "w-full rounded-lg border px-3 py-2 text-sm bg-gray-900 text-gray-200",
-              errors?.character ? "border-red-500" : "border-gray-700"
+              errors?.character ? "border-red-500" : "border-gray-700",
             )}
-            style={{ paddingTop: '2px', paddingBottom: '2px' }}
+            style={{ paddingTop: "2px", paddingBottom: "2px" }}
             value={character || ""}
-            onChange={e => onChange(idx, { character: e.target.value })}
+            onChange={(e) => onChange(idx, { character: e.target.value })}
           >
             <option value="">Select a character…</option>
             {characters.map((c) => (
-              <option key={c.name} value={c.name}>{c.name}</option>
+              <option key={c.name} value={c.name}>
+                {c.name}
+              </option>
             ))}
           </select>
-          {errors?.character && <p className="mt-1 text-xs text-red-400">{errors.character}</p>}
+          {errors?.character && (
+            <p className="mt-1 text-xs text-red-400">{errors.character}</p>
+          )}
         </div>
       </div>
     </div>
@@ -155,15 +316,16 @@ function ImmortalWarConfigurator() {
   const characterOptions = DEFAULT_CHARACTERS;
   // Hardcoded initial rounds
   const initial = useMemo(
-    () => ROUND_ROTATION.map((r, i) => ({
-      round: i + 1,
-      map: r.map,
-      mapImage: r.mapImage,
-      timeOfDay: r.timeOfDay,
-      fireflies: r.fireflies,
-      character: ""
-    })),
-    []
+    () =>
+      ROUND_ROTATION.map((r, i) => ({
+        round: i + 1,
+        map: r.map,
+        mapImage: r.mapImage,
+        timeOfDay: r.timeOfDay,
+        fireflies: r.fireflies,
+        character: "",
+      })),
+    [],
   );
 
   const [selections, setSelections] = useState(initial);
@@ -171,23 +333,28 @@ function ImmortalWarConfigurator() {
   const [showSummary, setShowSummary] = useState(false);
 
   const setField = (idx, partial) => {
-    setSelections(prev => {
+    setSelections((prev) => {
       const next = [...prev];
       next[idx] = { ...next[idx], ...partial };
       return next;
     });
     const keys = Object.keys(partial);
-    setTouched(prev => ({ ...prev, ...Object.fromEntries(keys.map(k => [[`${idx}-${k}`], true])) }));
+    setTouched((prev) => ({
+      ...prev,
+      ...Object.fromEntries(keys.map((k) => [[`${idx}-${k}`], true])),
+    }));
     setShowSummary(false);
   };
 
   // Per-round required-field errors
-  const perRoundErrors = useMemo(() =>
-    selections.map(sel => {
-      const e = {};
-      if (!sel.character) e.character = "Pick a character.";
-      return e;
-    }), [selections]
+  const perRoundErrors = useMemo(
+    () =>
+      selections.map((sel) => {
+        const e = {};
+        if (!sel.character) e.character = "Pick a character.";
+        return e;
+      }),
+    [selections],
   );
 
   // Character usage counts
@@ -203,16 +370,19 @@ function ImmortalWarConfigurator() {
 
   // Character constraints
   const characterConstraintError = useMemo(() => {
-    const offenders = Object.entries(charCounts).filter(([, c]) => c > 2).map(([n]) => n);
-    if (offenders.length) return `No character may be picked more than twice: ${offenders.join(", ")}.`;
-    const doubles = Object.values(charCounts).filter(c => c === 2).length;
+    const offenders = Object.entries(charCounts)
+      .filter(([, c]) => c > 2)
+      .map(([n]) => n);
+    if (offenders.length)
+      return `No character may be picked more than twice: ${offenders.join(", ")}.`;
+    const doubles = Object.values(charCounts).filter((c) => c === 2).length;
     if (doubles > 1) return "Only one character may be picked twice.";
     return "";
   }, [charCounts]);
 
   const allRoundsComplete = useMemo(
     () => perRoundErrors.every((e) => Object.keys(e).length === 0),
-    [perRoundErrors]
+    [perRoundErrors],
   );
 
   const formIsValid = allRoundsComplete && !characterConstraintError;
@@ -222,7 +392,9 @@ function ImmortalWarConfigurator() {
     // mark all fields touched so every missing field shows an error
     const allTouch = {};
     selections.forEach((_, idx) => {
-      ["map", "timeOfDay", "character"].forEach((k) => (allTouch[`${idx}-${k}`] = true));
+      ["map", "timeOfDay", "character"].forEach(
+        (k) => (allTouch[`${idx}-${k}`] = true),
+      );
     });
     setTouched(allTouch);
 
@@ -240,9 +412,12 @@ function ImmortalWarConfigurator() {
   return (
     <div className="max-w-6xl mx-auto p-4 md:p-8 text-gray-200">
       <header className="mb-4">
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-100">Immortal War - 6 Round Configurator</h1>
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-100">
+          Immortal War - 6 Round Configurator
+        </h1>
         <p className="text-sm text-gray-300 mt-1">
-          Configure map, time of day, and character for each round. Review is only enabled when all rules are satisfied.
+          Configure map, time of day, and character for each round. Review is
+          only enabled when all rules are satisfied.
         </p>
       </header>
 
@@ -259,14 +434,19 @@ function ImmortalWarConfigurator() {
           <div className="flex justify-center">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-2 gap-y-2 w-full">
               {selections.map((sel, idx) => (
-                <div key={sel.round} className="flex h-full min-h-[180px] max-h-[180px] max-w-xl w-full mx-auto">
+                <div
+                  key={sel.round}
+                  className="flex h-full min-h-[180px] max-h-[180px] max-w-xl w-full mx-auto"
+                >
                   <RoundCard
                     idx={idx}
                     selection={sel}
                     characters={characterOptions}
                     onChange={setField}
                     errors={{
-                      character: touched[`${idx}-character`] ? perRoundErrors[idx].character : undefined,
+                      character: touched[`${idx}-character`]
+                        ? perRoundErrors[idx].character
+                        : undefined,
                     }}
                   />
                 </div>
@@ -288,7 +468,7 @@ function ImmortalWarConfigurator() {
               type="submit"
               className={classNames(
                 "px-4 py-2 text-sm rounded-lg bg-yellow-500 text-gray-900 hover:bg-yellow-400",
-                !formIsValid && "opacity-60 cursor-not-allowed"
+                !formIsValid && "opacity-60 cursor-not-allowed",
               )}
               disabled={!formIsValid}
             >
@@ -319,21 +499,47 @@ function ImmortalWarConfigurator() {
               className="px-4 py-2 text-sm rounded-lg bg-yellow-500 text-gray-900 hover:bg-yellow-400"
               onClick={async () => {
                 // Export summary panel as PNG
-                const panel = document.querySelector('.summary-panel-export');
-                if (!panel) return alert('Summary panel not found.');
-                // Load html2canvas if not present
-                if (!window.html2canvas) {
-                  const script = document.createElement('script');
-                  script.src = 'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js';
+                const panel = document.querySelector(".summary-panel-export");
+                if (!panel) return alert("Summary panel not found.");
+                // Load html-to-image if not present
+                if (!window.htmlToImage) {
+                  const script = document.createElement("script");
+                  script.src =
+                    "https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js";
                   document.body.appendChild(script);
-                  await new Promise(res => { script.onload = res; });
+                  await new Promise((res) => {
+                    script.onload = res;
+                  });
                 }
-                window.html2canvas(panel, { backgroundColor: '#1a1a1a', useCORS: true }).then(canvas => {
-                  const link = document.createElement('a');
-                  link.download = 'immortal-config-summary.png';
-                  link.href = canvas.toDataURL('image/png');
-                  link.click();
+                const scale = 1280 / panel.offsetWidth;
+                const pngData = await window.htmlToImage.toPng(panel, {
+                  backgroundColor: "#1a1a1a",
+                  width: 1280,
+                  height: Math.floor(panel.offsetHeight * scale),
+                  style: {
+                    transform: `scale(${scale})`,
+                    transformOrigin: "top left",
+                  },
+                  cacheBust: true,
                 });
+                const img = new Image();
+                img.src = pngData;
+                await new Promise((res) => {
+                  img.onload = res;
+                });
+                const canvas = document.createElement("canvas");
+                canvas.width = 1280;
+                canvas.height = 720;
+                const ctx = canvas.getContext("2d");
+                const imgHeight = Math.floor(panel.offsetHeight * scale);
+                const yOffset = Math.max(0, (720 - imgHeight) / 2);
+                ctx.fillStyle = "#1a1a1a";
+                ctx.fillRect(0, 0, 1280, 720);
+                ctx.drawImage(img, 0, yOffset, 1280, imgHeight);
+                const link = document.createElement("a");
+                link.download = "immortal-config-summary.png";
+                link.href = canvas.toDataURL("image/png");
+                link.click();
               }}
             >
               Confirm & Export PNG

--- a/ScrimPrep/index.html
+++ b/ScrimPrep/index.html
@@ -1,71 +1,129 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="../favicon.png" />
-  <link rel="shortcut icon" href="../favicon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Immortal War Configurator</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.css" />
-  <style>
-    /* Match homepage background + overlay */
-    body{
-      background: url('../assets/naraka-bg.png') center/cover no-repeat fixed;
-      background-color: rgba(0,0,0,.85);
-      background-blend-mode: overlay;
-    }
-    /* Form control tweaks for visibility */
-    select, button { outline: none; }
-  </style>
-</head>
-<body class="bg-gray-900 text-gray-200 overflow-x-hidden">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="../favicon.png" />
+    <link rel="shortcut icon" href="../favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Immortal War Configurator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.css"
+    />
+    <style>
+      /* Match homepage background + overlay */
+      body {
+        background: url("../assets/naraka-bg.png") center/cover no-repeat fixed;
+        background-color: rgba(0, 0, 0, 0.85);
+        background-blend-mode: overlay;
+      }
+      /* Form control tweaks for visibility */
+      select,
+      button {
+        outline: none;
+      }
 
-  <!-- Back to Home -->
-  <header class="p-4">
-    <a href="../index.html"
-       onclick="return nav(event)"
-       class="inline-flex items-center gap-2 text-yellow-500 hover:text-yellow-400 transition">
-      ← Back to Home
-    </a>
-  </header>
+      /* Angled tile styles for map and hero images */
+      .angled-tile,
+      .hero-tile {
+        position: relative;
+        overflow: hidden;
+        transition: transform 0.3s ease;
+      }
+      .angled-tile {
+        clip-path: polygon(0 0, 100% 0, 100% 85%, 85% 100%, 0 100%);
+      }
+      .hero-tile {
+        clip-path: polygon(15% 0, 100% 0, 100% 100%, 0 100%, 0 15%);
+      }
+      .group:hover .angled-tile,
+      .group:hover .hero-tile {
+        transform: scale(1.05);
+      }
+      .angled-tile::before,
+      .hero-tile::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border: 2px solid rgba(250, 204, 21, 0.8); /* yellow */
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        pointer-events: none;
+      }
+      .group:hover .angled-tile::before,
+      .group:hover .hero-tile::before {
+        opacity: 1;
+      }
+    </style>
+  </head>
+  <body class="bg-gray-900 text-gray-200 overflow-x-hidden">
+    <!-- Back to Home -->
+    <header class="p-4">
+      <a
+        href="../index.html"
+        onclick="return nav(event)"
+        class="inline-flex items-center gap-2 text-yellow-500 hover:text-yellow-400 transition"
+      >
+        ← Back to Home
+      </a>
+    </header>
 
-  <!-- Page Title -->
-  <section class="text-center px-4" data-aos="fade-up">
-    <h1 class="text-3xl md:text-4xl font-bold">Immortal War – 6 Round Configurator</h1>
-    <p class="text-sm text-gray-300 mt-2">Pick map, time, and character for each round. Summary unlocks only when all rules pass.</p>
-  </section>
+    <!-- Page Title -->
+    <section class="text-center px-4" data-aos="fade-up">
+      <h1 class="text-3xl md:text-4xl font-bold">
+        Immortal War – 6 Round Configurator
+      </h1>
+      <p class="text-sm text-gray-300 mt-2">
+        Pick map, time, and character for each round. Summary unlocks only when
+        all rules pass.
+      </p>
+    </section>
 
-  <!-- Configurator Mount -->
-  <main id="root" class="max-w-6xl mx-auto mt-6 mb-16 px-4" data-aos="fade-up"></main>
+    <!-- Configurator Mount -->
+    <main
+      id="root"
+      class="max-w-6xl mx-auto mt-6 mb-16 px-4"
+      data-aos="fade-up"
+    ></main>
 
-  <!-- React + Babel -->
-  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <!-- React + Babel -->
+    <script
+      src="https://unpkg.com/react@18/umd/react.development.js"
+      crossorigin
+    ></script>
+    <script
+      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+      crossorigin
+    ></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
-  <!-- AOS + nav helper (same pattern as home) -->
-  <script src="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.js"></script>
-  <script>
-    if (window.AOS) AOS.init({ once: true, duration: 800 });
-    function nav(e){
-      if(!e) return true;
-      const link = e.currentTarget || e.target;
-      const href = link && link.getAttribute && link.getAttribute('href');
-      if(!href) return true;
-      e.preventDefault();
-      window.location.href = href;
-      return false;
-    }
-  </script>
+    <!-- AOS + nav helper (same pattern as home) -->
+    <script src="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.js"></script>
+    <script>
+      if (window.AOS) AOS.init({ once: true, duration: 800 });
+      function nav(e) {
+        if (!e) return true;
+        const link = e.currentTarget || e.target;
+        const href = link && link.getAttribute && link.getAttribute("href");
+        if (!href) return true;
+        e.preventDefault();
+        window.location.href = href;
+        return false;
+      }
+    </script>
 
-  <!-- Component (same folder) -->
-  <script type="text/babel" src="immortal_war_configurator_react.jsx"></script>
+    <!-- Component (same folder) -->
+    <script
+      type="text/babel"
+      src="immortal_war_configurator_react.jsx"
+    ></script>
 
-  <!-- Mount -->
-  <script type="text/babel">
-    ReactDOM.createRoot(document.getElementById('root'))
-      .render(<ImmortalWarConfigurator />);
-  </script>
-</body>
+    <!-- Mount -->
+    <script type="text/babel">
+      ReactDOM.createRoot(document.getElementById("root")).render(
+        <ImmortalWarConfigurator />,
+      );
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- modern angular tile styling with hover animations
- switch summary export to html-to-image at 1280x720
- remove preview page and screenshot assets

## Testing
- `npx prettier -w ScrimPrep/immortal_war_configurator_react.jsx ScrimPrep/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b2e688fda8832c959581402aaf5783